### PR TITLE
Add migration for manga_information to manga table.

### DIFF
--- a/app/Manga.php
+++ b/app/Manga.php
@@ -17,7 +17,7 @@ use \App\ImageArchive;
 class Manga extends Model
 {
     //
-    protected $fillable = ['name', 'path', 'library_id'];
+    protected $fillable = ['name', 'path', 'library_id', 'mu_id', 'description', 'type', 'year'];
 
     public function scopeSearch($query, $value)
     {

--- a/app/MangaInformation.php
+++ b/app/MangaInformation.php
@@ -48,6 +48,16 @@ class MangaInformation extends Model
         return $this->updated_at;
     }
 
+    public function manga()
+    {
+        return $this->belongsTo('App\Manga', 'id', 'id');
+    }
+
+    public function getManga()
+    {
+        return $this->manga;
+    }
+
     private function updateMangaInformation($mu_info)
     {
         if ($mu_info == null)

--- a/database/migrations/2017_11_07_204246_migrate_manga_information_to_manga_table.php
+++ b/database/migrations/2017_11_07_204246_migrate_manga_information_to_manga_table.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+use App\MangaInformation;
+
+class MigrateMangaInformationToMangaTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('manga', function (Blueprint $table) {
+            $table->unsignedInteger('mu_id')->nullable();
+            $table->text('description')->nullable();
+            $table->string('type', 20)->nullable();
+            $table->string('year', 4)->nullable();
+        });
+
+        // migrate existing data from manga_information table to manga table
+        $all = MangaInformation::all();
+        if ($all->count()) {
+            foreach ($all as $info) {
+                $manga = $info->manga;
+                if ($manga != null) {
+                    $manga->update([
+                        'mu_id' => $info->getMangaUpdatesId(),
+                        'description' => $info->getDescription(),
+                        'type' => $info->getType(),
+                        'year' => $info->getYear()
+                    ]);
+
+                    $manga->save();
+                }
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('manga', function (Blueprint $table) {
+            $table->dropColumn('mu_id');
+            $table->dropColumn('description');
+            $table->dropColumn('type');
+            $table->dropColumn('year');
+        });
+    }
+}


### PR DESCRIPTION
The manga table will now have the following columns from
manga_information:
mu_id, description, type, year

The migration will take care of copying existing data from
the manga_information table to manga table.