### PR TITLE
Advanced search now handles assoc. names. READ MORE.

### DIFF
--- a/app/AssociatedName.php
+++ b/app/AssociatedName.php
@@ -18,4 +18,14 @@ class AssociatedName extends Model
     {
         return $this->name;
     }
+
+    public function reference()
+    {
+        return $this->belongsTo('App\AssociatedNameReference', 'id', 'assoc_name_id');
+    }
+
+    public function scopeSearch($query, $keywords)
+    {
+        return empty($keywords) ? $query : $query->whereRaw('match(name) against(? in boolean mode)', [$keywords]);
+    }
 }

--- a/app/AssociatedNameReference.php
+++ b/app/AssociatedNameReference.php
@@ -23,4 +23,9 @@ class AssociatedNameReference extends Model
     {
         return $this->hasOne('App\AssociatedName', 'id', 'assoc_name_id');
     }
+
+    public function manga()
+    {
+        return $this->belongsTo('App\Manga');
+    }
 }

--- a/app/Http/Controllers/ArtistController.php
+++ b/app/Http/Controllers/ArtistController.php
@@ -38,7 +38,8 @@ class ArtistController extends Controller
                 array_push($results, $reference->manga);
         }
 
-        $results = collect($results);
+        $results = collect($results)->sortBy('name');
+
         $manga_list = new LengthAwarePaginator($results->forPage($page, 18), $results->count(), 18);
         $manga_list->withPath(\Request::getBaseUrl());
 

--- a/app/Http/Controllers/AuthorController.php
+++ b/app/Http/Controllers/AuthorController.php
@@ -38,7 +38,8 @@ class AuthorController extends Controller
                 array_push($results, $reference->manga);
         }
 
-        $results = collect($results);
+        $results = collect($results)->sortBy('name');
+
         $manga_list = new LengthAwarePaginator($results->forPage($page, 18), $results->count(), 18);
         $manga_list->withPath(\Request::getBaseUrl());
 

--- a/app/Http/Controllers/GenreController.php
+++ b/app/Http/Controllers/GenreController.php
@@ -38,7 +38,8 @@ class GenreController extends Controller
                 array_push($results, $reference->manga);
         }
 
-        $results = collect($results);
+        $results = collect($results)->sortBy('name');
+
         $manga_list = new LengthAwarePaginator($results->forPage($page, 18), $results->count(), 18);
         $manga_list->withPath(\Request::getBaseUrl());
 

--- a/app/Manga.php
+++ b/app/Manga.php
@@ -201,7 +201,20 @@ class Manga
 
     public function scopeSearch($query, $keywords)
     {
-        return empty($keywords) ? $query : $query->whereRaw("match(name) against(? in boolean mode)", [$keywords]);
+        $results = $query->whereRaw("match(name) against(? in boolean mode)", [$keywords])->get();
+
+        // get the associated names that match
+        $assocNames = AssociatedName::search($keywords)->get();
+        $assocArray = [];
+        // convert the associated names to a manga object and store them in an array
+        foreach ($assocNames as $assocName) {
+            array_push($assocArray, $assocName->reference->manga);
+        }
+
+        // convert the associated name array to an Illuminate\Support\Collection and merge
+        $results = $results->merge(collect($assocArray));
+
+        return empty($keywords) ? $query : $results;
     }
 
     /**
@@ -219,14 +232,12 @@ class Manga
         $libraryIds = LibraryPrivilege::getIds(\Auth::user()->getId());
         $collection = null;
 
-        // get an Illuminate\Support\Collection object depending on whether keywords are present
+        // get a Collection object depending on whether keywords are present
         if (empty($keywords) == false) {
             $collection = Manga::whereRaw("match(name) against(? in boolean mode)", [$keywords])->get();
         } else {
             $collection = Manga::all();
         }
-
-        $collection = $collection->sortBy('name');
 
         // filter by library permissions
         $collection = $collection->whereIn('library_id', $libraryIds);

--- a/database/migrations/2018_05_02_200608_add_full_text_index_to_associated_names_table.php
+++ b/database/migrations/2018_05_02_200608_add_full_text_index_to_associated_names_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddFullTextIndexToAssociatedNamesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement('CREATE FULLTEXT INDEX assoc_name_index ON associated_names(name);');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('associated_names', function (BLueprint $table) {
+            $table->dropIndex('assoc_name_index');
+        });
+    }
+}

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -64,7 +64,7 @@
                         <li>
                             <a href="{{ URL::action('FavoriteController@index') }}"><span class="glyphicon glyphicon-heart"></span>&nbsp;Favorites</a>
                             <a href="{{ URL::action('UserSettingsController@index') }}"><span class="glyphicon glyphicon-cog"></span>&nbsp;Settings</a>
-                            <a href="{{ URL::action('LoginController@logout') }}"><span class="glyphicon glyphicon-log-out"></span>&nbsp;Logout</a>
+                            <a href="{{ URL::action('LoginController@logout') }}"><span class="glyphicon glyphicon-off"></span>&nbsp;Logout</a>
                         </li>
                     </ul>
                 </li>


### PR DESCRIPTION
This commit contains a migration. You will need to run php artisan
mangapie:init

This is ONLY for advanced search, not for the autocomplete.
I have written the code for it but have it commented out.
I'm not sure if autocomplete should also include associated names.